### PR TITLE
fix Typo $grid => $filter

### DIFF
--- a/2.x/model-grid-filters.md
+++ b/2.x/model-grid-filters.md
@@ -36,7 +36,7 @@ use Dcat\Admin\Grid;
 
 $grid->filter(function (Grid\Filter $filter) {
     // 更改为 rightSide 布局
-    $grid->rightSide();
+    $filter->rightSide();
     
     ...
 });


### PR DESCRIPTION
筛选器布局按钮的变量名错误